### PR TITLE
添加对Mac 系统中文字体的支持

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass[master,euler,twoside,openright]{ustcthesis}
+\documentclass[master,euler,twoside,openright,macfonts]{ustcthesis}
 % 默认twoside 双面打印
 % 将master修改为bachelor, doctor or master
 % 要使用adobe字体，添加adobefonts选项

--- a/main.tex
+++ b/main.tex
@@ -2,7 +2,7 @@
 % 默认twoside 双面打印
 % 将master修改为bachelor, doctor or master
 % 要使用adobe字体，添加adobefonts选项
-% 要是用Mac系统的字体，添加macfonts选项
+% 要使用Mac系统的字体，添加macfonts选项
 % 使用euler数学字体，如不愿使用，去掉euler
 % 使用外文写作，请添加notchinese
 

--- a/main.tex
+++ b/main.tex
@@ -1,7 +1,8 @@
-﻿\documentclass[master,euler,twoside,openright]{ustcthesis}
+\documentclass[master,euler,twoside,openright]{ustcthesis}
 % 默认twoside 双面打印
 % 将master修改为bachelor, doctor or master
 % 要使用adobe字体，添加adobefonts选项
+% 要是用Mac系统的字体，添加macfonts选项
 % 使用euler数学字体，如不愿使用，去掉euler
 % 使用外文写作，请添加notchinese
 

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -1,4 +1,4 @@
-﻿%
+%
 % University of Science and Technology of China Thesis Template
 % For Bachelor Master and Doctor
 %
@@ -21,6 +21,7 @@
 \newif\ifustc@doctor\ustc@doctorfalse
 \newif\ifustc@bachelor\ustc@bachelorfalse
 \newif\ifustc@adobefont\ustc@adobefontfalse
+\newif\ifustc@macfont\ustc@macfontfalse
 \newif\ifustc@euler\ustc@eulerfalse
 \newif\ifustc@notchinese\ustc@notchinesefalse
 
@@ -47,6 +48,9 @@
 %Enhance compatibility
 \DeclareOption{adobefonts}{\ustc@adobefonttrue\PassOptionsToClass{adobefonts}{ctexbook}}
 \DeclareOption{adobefont}{\ustc@adobefonttrue\PassOptionsToClass{adobefonts}{ctexbook}}
+\DeclareOption{macfonts}{\ustc@macfonttrue\PassOptionsToClass{nofonts}{ctexbook}}
+
+
 
 %Pass all unprocessed/unknown options to ctexbook. If a wrong option is specified, perhaps ctexbook will throw an error.
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{ctexbook}}
@@ -173,10 +177,25 @@
 %Define font for vertical typesetting.
 \ifustc@adobefont
 	\setCJKfamilyfont{verthei}[RawFeature={vertical:}]{Adobe Heiti Std}\relax
-\else%
-	\setCJKfamilyfont{verthei}[RawFeature={vertical:}]{SimHei}\relax
+\else
+	\ifustc@macfont
+		\setCJKfamilyfont{verthei}[RawFeature={vertical:}]{Heiti SC}\relax
+	\else
+		\setCJKfamilyfont{verthei}[RawFeature={vertical:}]{SimHei}\relax
+	\fi
 \fi
 \newcommand{\ustc@verthei}{\CJKfamily{verthei}}
+
+
+\ifustc@macfont
+	\setCJKmainfont[BoldFont={Heiti SC}, ItalicFont={Kaiti SC}]{Songti SC}
+	\setCJKsansfont{Heiti SC}
+	\setCJKmonofont{STFangsong}
+	\setCJKfamilyfont{song}{Songti Sc}
+	\setCJKfamilyfont{hei}{Heiti SC}
+	\setCJKfamilyfont{kai}{Kaiti SC}
+	\setCJKfamilyfont{fs}{STFangsong}
+\fi
 
 %Set section numbering to subsubsection
 \setcounter{secnumdepth}{3}


### PR DESCRIPTION
Mac 系统下只有自己的中文字体：Songti SC, Heiti SC, Kaiti SC, STFangsong
我在ustcthesis.cls文档类添加了一个选项用于调用这些字体
