### PR TITLE
修复英文标题页字体错误

### DIFF
--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -480,9 +480,9 @@
   \thispagestyle{empty}
   \begin{center}
     \vspace*{0cm}
-      \USTCLarge{\ttfamily{University of Science and Technology of China}}
+      \USTCLarge{\sffamily{University of Science and Technology of China}}
     \vskip -0.2cm %-0.6cm
-    \USTCLARGE{\ttfamily\ifustc@doctor
+    \USTCLARGE{\sffamily\ifustc@doctor
       {A dissertation for doctor's degree}
     \else\ifustc@master
       {A dissertation for master's degree}
@@ -493,7 +493,7 @@
       \includegraphics[width=4.7cm]{ustc_logo_fig.eps}
     \vskip 1.5cm %2.4cm
       \renewcommand{\baselinestretch}{1}
-      \bfseries\yihao\ustc@entitle
+      \sffamily\bfseries\yihao\ustc@entitle
   \end{center}
   \vskip 1.0cm %1.8cm 2cm 3.1cm
   \begin{center}

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -480,20 +480,20 @@
   \thispagestyle{empty}
   \begin{center}
     \vspace*{0cm}
-      \USTCLarge{\sffamily{University of Science and Technology of China}}
+      \USTCLarge{\textsf{University of Science and Technology of China}}
     \vskip -0.2cm %-0.6cm
-    \USTCLARGE{\sffamily\ifustc@doctor
+    \USTCLARGE{\textsf{\ifustc@doctor
       {A dissertation for doctor's degree}
     \else\ifustc@master
       {A dissertation for master's degree}
     \else
       {A dissertation for bachelor's degree}
-    \fi\fi}
+    \fi\fi}}
     \vskip 1.5cm %1.25cm
       \includegraphics[width=4.7cm]{ustc_logo_fig.eps}
     \vskip 1.5cm %2.4cm
       \renewcommand{\baselinestretch}{1}
-      \sffamily\bfseries\yihao\ustc@entitle
+      \textsf{\bfseries\yihao\ustc@entitle}
   \end{center}
   \vskip 1.0cm %1.8cm 2cm 3.1cm
   \begin{center}
@@ -542,9 +542,9 @@
   \thispagestyle{empty}
   \begin{center}
     \vspace*{0cm}
-      \USTCLarge{\ttfamily{\ustc@otherustcstr}}
+      \USTCLarge{\texttt{\ustc@otherustcstr}}
     \vskip -0.2cm %-0.6cm
-    \USTCLARGE{\ttfamily\ustc@otherthesisstr}
+    \USTCLARGE{\texttt{\ustc@otherthesisstr}}
     \vskip 1.5cm %1.25cm
       \includegraphics[width=4.7cm]{ustc_logo_fig.eps}
     \vskip 1.5cm %2.4cm

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -807,9 +807,9 @@
 	\newcommand{\ustc@thanksname}{致\hspace{\ccwd}谢}
 \fi
 \newcommand\keywords[1]{%
-  \vspace{3.5ex}\noindent{\bfseries 关键词：~} #1}
+  \vspace{3.5ex}\noindent{\textbf{关键词：~}} #1}
 \newcommand\enkeywords[1]{%
-  \vspace{3.5ex}\noindent{\bf Keywords:~} #1}
+  \vspace{3.5ex}\noindent{\textbf{Keywords:~}} #1}
 \newenvironment{cnabstract}
   {\ifustc@bachelor\chapter{\texorpdfstring{\ustc@cnabstractname}{摘要}}\else\chapter[\texorpdfstring{\ustc@cnabstractname}{摘要}]{\protect\vskip-10pt\ustc@cnabstractname}\fi}
   {}


### PR DESCRIPTION
1. 规范中要求英文页的校名、论文名为Arial字体，该字体为无衬线字体，应使用`sffamily`，而不是`ttfamily`.
2. 不推荐使用`\bf`
3. `\bfseries`和`\textbf{}`的功能是一样的，但前者一般用于设置大段字体，而后者一般用于设置短文本的字体。

参考：
1. http://tex.stackexchange.com/questions/516/
2. http://tex.stackexchange.com/questions/11199
3. http://tex.stackexchange.com/questions/41681
